### PR TITLE
don't send port number in SNI name

### DIFF
--- a/fuzzer/connection.go
+++ b/fuzzer/connection.go
@@ -332,7 +332,7 @@ func Dial(host string, isTLS bool) (net.Conn, error) {
 
 	if isTLS {
 		cfg := &tls.Config{
-			ServerName:         host,
+			ServerName:         strings.Split(host, ":")[0],
 			NextProtos:         []string{"h2", "h2-14"},
 			InsecureSkipVerify: true,
 		}


### PR DESCRIPTION
I noticed when testing http2fuzzer that my server logs showed an error in the SNI name: It contained the :443 port number.
Likely the server will throw away connections early and the fuzzer may be less effective, therefore better fix it.
